### PR TITLE
リリースを Release PR 方式にし、crates.io 向けのメタデータを追加する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,89 @@
 name: Release
 
-# Releasesへのファイル追加のために書き込み権限が必要
-permissions:
-  contents: write
-
+# リリースは Release PR 方式で行う。
+#   1. main へのマージごとに、バージョンと CHANGELOG を更新する Release PR が作られる/更新される
+#   2. その Release PR をマージすると、tag と GitHub Release が作られ、バイナリが添付される
+# tag を手で打って push する必要はない。
 on:
   push:
-    tags:
-      - v*
+    branches:
+      - main
 
 jobs:
-  build:
+  # 未リリースのコミットから Release PR を作る/更新する。
+  release-pr:
+    name: Release PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Create release PR
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Release PR がマージされた回だけ、tag と GitHub Release を作る。
+  # バージョンが変わっていない普通のマージでは何も起きない。
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    outputs:
+      released: ${{ steps.release-plz.outputs.releases_created }}
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Create release
+        id: release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract tag
+        id: tag
+        if: steps.release-plz.outputs.releases_created == 'true'
+        env:
+          RELEASES: ${{ steps.release-plz.outputs.releases }}
+        run: echo "tag=$(jq -r '.[0].tag' <<<"$RELEASES")" >> "$GITHUB_OUTPUT"
+
+  # ビルド済みバイナリを Release に添付する。
+  #
+  # GITHUB_TOKEN が作った tag は他の workflow を起動しないため、
+  # tag push をトリガーにせず、同じ workflow の中でビルドする。
+  upload-binary:
+    name: Upload binary
+    needs: release
+    if: needs.release.outputs.released == 'true'
     runs-on: ${{ matrix.job.os }}
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -19,47 +91,30 @@ jobs:
           - {
               os: ubuntu-latest,
               target: x86_64-unknown-linux-gnu,
-              use-cross: false,
               extension: "",
             }
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.tag }}
 
-      # Rustのpackage名を取得して環境変数に入れておく。(後のステップで使用)
-      - name: Extract crate information
-        shell: bash
-        run: |
-          echo "PROJECT_NAME=$(sed -n 's/^name = "\(.*\)"/\1/p' Cargo.toml | head -n1)" >> $GITHUB_ENV
-
-      # rustcやcargoをインストール
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          target: ${{ matrix.job.target }}
-          override: true
-          profile: minimal
+          targets: ${{ matrix.job.target }}
 
-      # targetに応じてcargoもしくはcrossを使用してビルド
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: ${{ matrix.job.use-cross }}
-          command: build
-          args: --release --target ${{ matrix.job.target }}
+        run: cargo build --release --target ${{ matrix.job.target }}
 
-      # ビルド済みバイナリをリネーム
-      - name: Rename artifacts
-        shell: bash
+      - name: Rename artifact
         run: |
-          mv target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}{,-${{ matrix.job.target }}${{ matrix.job.extension }}}
+          mv target/${{ matrix.job.target }}/release/zakki${{ matrix.job.extension }} \
+             zakki-${{ matrix.job.target }}${{ matrix.job.extension }}
 
-      # ビルド済みバイナリをReleasesに配置
-      - name: Release
-        uses: softprops/action-gh-release@v1
+      - name: Upload to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          files: |
-            target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}-${{ matrix.job.target }}${{ matrix.job.extension }}
+        run: |
+          gh release upload "${{ needs.release.outputs.tag }}" \
+            "zakki-${{ matrix.job.target }}${{ matrix.job.extension }}" --clobber

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 name = "zakki"
 version = "0.18.0"
 edition = "2024"
+description = "A static site generator with per-page encryption and serverless full-text search"
+license = "MIT"
+repository = "https://github.com/sinotca529/zakki"
+readme = "README.md"
+keywords = ["static-site", "ssg", "markdown", "blog", "generator"]
+categories = ["command-line-utilities", "text-processing"]
+exclude = ["/.github"]
 
 [profile.release]
 strip = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,3 @@
+[workspace]
+# crates.io には publish せず、リリース済みバージョンは git tag (v0.18.0 形式) から判定する。
+git_only = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,3 +1,5 @@
 [workspace]
-# crates.io には publish せず、リリース済みバージョンは git tag (v0.18.0 形式) から判定する。
+# リリース済みバージョンは cargo レジストリではなく git tag (v0.18.0 形式) から判定する。
 git_only = true
+# crates.io への publish は行わない (git_only を使う場合は明示が必須)。
+publish = false


### PR DESCRIPTION
## 概要

tag を手で打って push する運用をやめ、release-plz による Release PR 方式に変更します。あわせて crates.io に publish できるだけのパッケージメタデータを整えます。

リリース手順は次のようになります。

1. 普段どおり main へマージする
2. release-plz が「バージョンと CHANGELOG を更新する Release PR」を作り、以降のマージのたびに更新する
3. リリースしたくなったら、その Release PR をマージする
4. tag・GitHub Release・バイナリ添付が自動で走る

## 変更点

### `Cargo.toml`

`cargo publish` に必須の `description` と `license` に加え、`repository` / `readme` / `keywords` / `categories` を追加しました。`exclude = ["/.github"]` で workflow をパッケージから除いています。

### `release-plz.toml` (新規)

`git_only = true` を設定しています。crates.io への publish は行わず、リリース済みバージョンを git tag (`v0.18.0` 形式) から判定するモードです。既存の tag がそのまま基準になります。

### `.github/workflows/release.yml`

tag push トリガーから main への push トリガーに変更し、3 つの job で構成しました。

- `release-pr`: Release PR を作成・更新する
- `release`: Release PR がマージされた回だけ tag と GitHub Release を作る（バージョンが変わらない普通のマージでは何も起きない）
- `upload-binary`: リリースが作られた場合のみ、バイナリをビルドして Release に添付する

**`GITHUB_TOKEN` で作った tag は他の workflow を起動しない**ため、バイナリのビルドは tag push をトリガーにせず、同じ workflow 内で `release` job の出力を受けて実行しています。

ついでに、アーカイブ済みの `actions-rs/toolchain` と `actions-rs/cargo` を `dtolnay/rust-toolchain` + `cargo` の直呼びに、`actions/checkout@v2` を `@v4` に更新しました。

## 確認

- `cargo publish --dry-run` 成功（メタデータ検証・パッケージング・パッケージからのビルドまで）
- workflow の YAML パースを確認

## マージ後に必要なこと

- **コミットメッセージを Conventional Commits に寄せる**。`feat:` で minor、`fix:` で patch、`feat!:` または `BREAKING CHANGE` で major が上がります。この PR の 2 コミットはその形式で書いています。規約から外れたコミットも CHANGELOG に載りますが、バージョンの判定材料にはなりません。
- **最初の Release PR の内容を確認する**。既存 tag `v0.18.0` を基準に次バージョンが決まります。

## 判断が必要な点

**crates.io への publish は自動化していません。** publish はバージョンの取り消しができない不可逆な操作で、crate 名 `zakki` の占有も伴うため、最初の 1 回はご自身の判断で `cargo publish` していただくのが安全だと考えました。自動化に切り替える場合は、`release-plz.toml` の `git_only` を外し、`CARGO_REGISTRY_TOKEN` を secret に登録して workflow に渡す形になります。

なお、バイナリを配布する以上は依存クレートのライセンス表示義務があります（直接依存 19 個はすべて permissive で、コピーレフトはありません）。`cargo-about` で `THIRD-PARTY-LICENSES` を生成して Release に添付する対応は、この PR には含めていません。

---
_Generated by [Claude Code](https://claude.ai/code/session_01QE3NNGCQGM4dfSuLyiJwWw)_