### PR TITLE
docs: 画像などの配置に関する記述を実装に合わせる

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Zakki のディレクトリ構造は次のようになっています。
 
 ### 記事の追加
 
-Markdown ファイルは `public/`, `private/`, `/draft` 下に直接配置します。
+Markdown ファイルは `public/`, `private/`, `draft/` 下に配置します。
+
 ```txt
 .
 └── src
@@ -86,15 +87,20 @@ Markdown ファイルは `public/`, `private/`, `/draft` 下に直接配置し�
       └── foo.md
 ```
 
-画像ファイルなどがある場合は、ファイル名と同名のディレクトリを作成し、そこに配置します。
+画像などの Markdown 以外のファイルは、`src/` 内の位置関係を保ったまま `build/` 下にコピーされます。
+Markdown からは相対パスでそのまま参照できます。
+
+記事に関連するファイルをまとめる置き方は、例えば次のどちらでも構いません。
 
 ```txt
 .
-└── src
-   └── public
-      ├── foo.md
-      └── foo
-        └── img.png
+└── src/public/
+   ├── foo.md        # ![](foo/img.png) と参照する
+   ├── foo/
+   │  └── img.png
+   └── bar/
+      ├── index.md   # ![](img.png) と参照する
+      └── img.png
 ```
 
 ### ページのメタデータ


### PR DESCRIPTION
## 概要

README の「記事の追加」が、画像などの配置について実装より狭い規則を書いていたので、事実に合わせます。

## 何が違っていたか

README は「画像ファイルなどがある場合は、ファイル名と同名のディレクトリを作成し、そこに配置します」と義務のように書いていましたが、**同名ディレクトリを特別扱いする処理は実装にありません**（`file_stem` も使われていません）。パス変換は `src/path.rs` のこれだけです。

```rust
if rel.extension_is("md") {
    Ok(zakki_dst_dir()?.join(rel.with_extension("html")))  // .md → .html
} else {
    Ok(zakki_dst_dir()?.join(rel))                          // それ以外はそのままコピー
}
```

画像の URL も Markdown に書かれたまま出力され、書き換えられるのは `.md` → `.html` のリンクだけです。つまり実際の規則は「Markdown 以外のファイルは `src/` 内の位置関係を保ったまま `build/` にコピーされる」だけで、相対パスさえ合っていれば配置は自由です。

README 内でも噛み合っていませんでした。「サブページ」の節ではすでに `bar/index.md` 方式を紹介しており、同名ディレクトリ方式に限定する記述と整合していません。

## 確認

両方のレイアウトでビルドし、どちらも成立することを確認しました。

```txt
src/public/foo.md       + src/public/foo/img.png  →  build/public/foo.html       src="foo/img.png"
src/public/bar/index.md + src/public/bar/img.png  →  build/public/bar/index.html src="img.png"
```

## 変更点

- 実際の規則（相対位置を保ってコピーされること）を明記
- 配置例を、同名ディレクトリ方式と `index.md` 方式の両方を含む 1 つのツリーに変更。どちらかを推奨する書き方はしていません
- 同じ段落の表記揺れ `/draft` を `draft/` に修正

---
_Generated by [Claude Code](https://claude.ai/code/session_01QE3NNGCQGM4dfSuLyiJwWw)_